### PR TITLE
fix: using latest standards for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "rango-types",
   "version": "0.1.63",
   "description": "Rango Exchange Types",
-  "main": "lib/index.js",
   "type": "module",
-  "types": "lib",
+  "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
   "repository": "https://github.com/rango-exchange/rango-types",
   "homepage": "https://github.com/rango-exchange/rango-types",
   "bugs": {


### PR DESCRIPTION
# Summary

We were pointing to `lib` for `types` field in `package.json`. It's not working correctly for Typescript consumer with `module` and `moduleResolution` set to `NodeNext` since it needs full path explicitly. Also changed `types` to `typings` since more appropriate.

I also added `exports` field which is final standard for Node. 