### PR TITLE
chore: add mainApi and basicApi to exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     ".": {
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
+    },
+    "./main": {
+      "types": "./lib/api/main/index.d.ts",
+      "default": "./lib/api/main/index.js"
+    },
+    "./basic": {
+      "types": "./lib/api/basic/index.d.ts",
+      "default": "./lib/api/basic/index.js"
     }
   },
   "repository": "https://github.com/rango-exchange/rango-types",


### PR DESCRIPTION
# Summary

In ESM, all the imports will be matched to `exports` field which means unlike before you can not access to internal files using a path. for example `rango-types/lib/main/api` will not work anymore. 
So user has access to what explicitly defined in `exports` since we have some name collision in Main an Basic api some of the types/functions will not be accessible through our entry point `lib/index.js`. 
 
 I added two more `exports` to solve the issue. ESM users will use something like this `import { ...} from "rango-types/mainApi"`