### PR TITLE
chore: rename main to mainApi and basic to basicApi for esm exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "./main": {
+    "./mainApi": {
       "types": "./lib/api/main/index.d.ts",
       "default": "./lib/api/main/index.js"
     },
-    "./basic": {
+    "./basicApi": {
       "types": "./lib/api/basic/index.d.ts",
       "default": "./lib/api/basic/index.js"
     }


### PR DESCRIPTION
rename exported names to be more compatible with what we are exporting from `index.js`