### PR TITLE
fix: rename pbt to ptb

### DIFF
--- a/src/api/main/txs/sui.ts
+++ b/src/api/main/txs/sui.ts
@@ -2,7 +2,7 @@ import { BaseTransaction, TransactionType } from '../../shared/index.js'
 
 export interface SuiTransaction extends BaseTransaction {
   type: TransactionType.SUI
-  unsignedPbtBase64: string
+  unsignedPtbBase64: string
 }
 
 export const isSuiTransaction = (transaction: {


### PR DESCRIPTION
We used pbt instead of ptb mistakenly.