### PR TITLE
chore: set up husky hooks for post-commit

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ -z "${GIT_COMMITTER_DATE:-}" ]; then
+    DATE="$(date -u +%Y-%m-%dT%H:%M:%S%z)";
+    export GIT_AUTHOR_DATE="$DATE";
+    export GIT_COMMITTER_DATE="$DATE"
+    git commit --amend --date "$DATE" --no-edit
+fi

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build": "tsc",
     "lint": "eslint */**/*.{js,ts} --quiet --fix",
     "semantic-release": "semantic-release",
-    "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"
+    "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc",
+    "postinstall": "husky install"
   },
   "keywords": [
     "Rango Exchange",
@@ -51,10 +52,10 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
+    "husky": "^8.0.3",
     "prettier": "^2.8.3",
     "typescript": "^4.9.4"
   },
-  "dependencies": {},
   "publishConfig": {
     "access": "public",
     "branches": [


### PR DESCRIPTION
This change sets up Husky in the project and adds support for post-commit hooks to automate tasks such as running scripts after commits or merges.