### PR TITLE
fix: rename preconditions to prerequisites

### DIFF
--- a/src/api/shared/txs/base.ts
+++ b/src/api/shared/txs/base.ts
@@ -8,18 +8,18 @@ import { TransactionType } from '../transactions.js'
  *
  */
 export interface BaseTransaction<
-  P extends BaseTransactionPrecondition = never
+  P extends BaseTransactionPrerequisite = never
 > {
   type: TransactionType
   blockChain: string
-  preconditions: P[]
+  prerequisites: P[]
 }
 
-type TransactionPreconditionsType =
+type TransactionPrerequisitesType =
   | 'STELLAR_CHANGE_TRUSTLINE'
   | 'XRPL_CHANGE_TRUSTLINE'
 
-export interface BaseTransactionPrecondition {
-  type: TransactionPreconditionsType
+export interface BaseTransactionPrerequisite {
+  type: TransactionPrerequisitesType
   blockChain: string
 }

--- a/src/api/shared/txs/hyperliquid.ts
+++ b/src/api/shared/txs/hyperliquid.ts
@@ -17,7 +17,7 @@ interface HyperliquidAction {
  * @property {HyperliquidAction} action - Hyperliquid transaction action
  * @property {string} message, message to be signed by wallet
  * @property {string} nonce, nonce of transaction
- * @property {string} preconditions, This field is an empty array for Hyperliquid transactions
+ * @property {string} prerequisites, This field is an empty array for Hyperliquid transactions
  * @property {string | null} expectedOutput, expected output of transaction
  *
  */
@@ -26,7 +26,7 @@ export interface HyperliquidTransaction extends BaseTransaction {
   action: HyperliquidAction
   message: string
   nonce: number
-  preconditions: []
+  prerequisites: []
   expectedOutput: string
 }
 

--- a/src/api/shared/txs/stellar.ts
+++ b/src/api/shared/txs/stellar.ts
@@ -1,11 +1,11 @@
 import {
   BaseTransaction as RangoBaseTransaction,
   TransactionType,
-  BaseTransactionPrecondition,
+  BaseTransactionPrerequisite,
 } from '../../shared/index.js'
 
 /**
- *  Stellar Precondition Type
+ *  Stellar Prerequisite Type
  *
  * @property {string} type equals to STELLAR_CHANGE_TRUSTLINE
  * @property {string} blockChain, equals to STELLAR
@@ -15,8 +15,8 @@ import {
  * @property {string} wallet User's wallet address which must have this trustline allowed for the stellar asset
  *
  */
-export interface StellarChangeTrustLinePrecondition
-  extends BaseTransactionPrecondition {
+export interface StellarChangeTrustLinePrerequisite
+  extends BaseTransactionPrerequisite {
   type: 'STELLAR_CHANGE_TRUSTLINE'
   blockChain: 'STELLAR'
   code: string
@@ -26,7 +26,7 @@ export interface StellarChangeTrustLinePrecondition
 }
 
 export interface StellarTransaction
-  extends RangoBaseTransaction<StellarChangeTrustLinePrecondition> {
+  extends RangoBaseTransaction<StellarChangeTrustLinePrerequisite> {
   type: TransactionType.STELLAR
   xdrBase64: string
 }

--- a/src/api/shared/txs/xrpl.ts
+++ b/src/api/shared/txs/xrpl.ts
@@ -1,11 +1,11 @@
 import {
   BaseTransaction as RangoBaseTransaction,
   TransactionType,
-  BaseTransactionPrecondition,
+  BaseTransactionPrerequisite,
 } from '../../shared/index.js'
 
-export interface XrplChangeTrustLinePrecondition
-  extends BaseTransactionPrecondition {
+export interface XrplChangeTrustLinePrerequisite
+  extends BaseTransactionPrerequisite {
   type: 'XRPL_CHANGE_TRUSTLINE'
   blockChain: 'XRPL'
   /** Xrpl Currency **/
@@ -19,7 +19,7 @@ export interface XrplChangeTrustLinePrecondition
 }
 
 export interface XrplTransaction
-  extends RangoBaseTransaction<XrplChangeTrustLinePrecondition> {
+  extends RangoBaseTransaction<XrplChangeTrustLinePrerequisite> {
   type: TransactionType.XRPL
   data: Payment | TrustSet
 }


### PR DESCRIPTION
`preconditions` was renamed to `prerequisites` to be compatible with the Rango API response.